### PR TITLE
Book Service: Load DB with external books

### DIFF
--- a/src/main/java/com/group11/shelftalk/config/AppConfig.java
+++ b/src/main/java/com/group11/shelftalk/config/AppConfig.java
@@ -1,0 +1,13 @@
+package com.group11.shelftalk.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    } 
+}

--- a/src/main/java/com/group11/shelftalk/service/BookService.java
+++ b/src/main/java/com/group11/shelftalk/service/BookService.java
@@ -1,0 +1,95 @@
+package com.group11.shelftalk.service;
+
+import com.group11.shelftalk.models.Book;
+import com.group11.shelftalk.repository.BookRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.http.ResponseEntity;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Service
+public class BookService {
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    private static final String[] GENRES = {
+            "Drama", "Fable", "Fairy Tale", "Fantasy", "Fiction", "Folklore", "Historical Fiction",
+            "Horror", "Humor", "Legend", "Mystery", "Mythology", "Poetry", "Science Fiction", "Tall Tale"
+    };
+
+    private static final int TOTAL_BOOKS = 1500;
+    private static final int BOOKS_PER_GENRE = TOTAL_BOOKS / GENRES.length;
+
+    public void fetchAndSaveBooks() {
+        Set<String> fetchedIsbns = new HashSet<>();
+
+        for (String genre : GENRES) {
+            System.out.println("Starting to fetch books for genre: " + genre);
+            fetchBooksByGenre(genre, BOOKS_PER_GENRE, fetchedIsbns);
+            System.out.println("Finished fetching books for genre: " + genre);
+        }
+    }
+
+    private void fetchBooksByGenre(String genre, int limit, Set<String> fetchedIsbns) {
+        int fetchedCount = 0;
+        int page = 1;
+
+        while (fetchedCount < limit) {
+            String apiUrl = "https://openlibrary.org/search.json?q=subject:" + genre.toLowerCase() + "&page=" + page;
+            ResponseEntity<OpenLibraryResponse> response = restTemplate.getForEntity(apiUrl, OpenLibraryResponse.class);
+            OpenLibraryResponse openLibraryResponse = response.getBody();
+
+            if (openLibraryResponse != null && openLibraryResponse.getDocs() != null) {
+                for (OpenLibraryBook openLibraryBook : openLibraryResponse.getDocs()) {
+                    if (fetchedCount >= limit) {
+                        break;
+                    }
+
+                    String isbn = openLibraryBook.getIsbn() != null && !openLibraryBook.getIsbn().isEmpty() ? openLibraryBook.getIsbn().get(0) : null;
+                    if (isbn != null && !fetchedIsbns.contains(isbn)) {
+                        fetchedIsbns.add(isbn);
+                        String coverImgUrl = null;
+                        if (openLibraryBook.getCover_i() != null) {
+                            coverImgUrl = "https://covers.openlibrary.org/b/id/" + openLibraryBook.getCover_i() + "-L.jpg";
+                        } else if (openLibraryBook.getCover_edition_key() != null) {
+                            coverImgUrl = "https://covers.openlibrary.org/b/olid/" + openLibraryBook.getCover_edition_key() + "-L.jpg";
+                        }
+
+                        // Truncate summary to 200 characters and add "..." if it's too long
+                        String summary = openLibraryBook.getFirst_sentence() != null && !openLibraryBook.getFirst_sentence().isEmpty() ? openLibraryBook.getFirst_sentence().get(0) : "";
+                        if (summary.length() > 200) {
+                            summary = summary.substring(0, 200) + "...";
+                        }
+
+                        // Create book object and save to DB
+                        Book book = new Book(
+                                openLibraryBook.getTitle(),
+                                isbn,
+                                openLibraryBook.getNumber_of_pages_median() != null ? openLibraryBook.getNumber_of_pages_median() : 0,
+                                openLibraryBook.getAuthor_name() != null && !openLibraryBook.getAuthor_name().isEmpty() ? openLibraryBook.getAuthor_name().get(0) : null,
+                                genre,
+                                summary,
+                                coverImgUrl
+                        );
+
+                        bookRepository.save(book);
+                        fetchedCount++;
+
+                        System.out.println("Added book: " + openLibraryBook.getTitle() + " (ISBN: " + isbn + ")");
+                    }
+                }
+            }
+            page++;
+
+            System.out.println("Fetched " + fetchedCount + " books for genre: " + genre + " (Page " + page + ")");
+        }
+
+        System.out.println("Completed fetching books for genre: " + genre + ". Total books added: " + fetchedCount);
+    }
+}

--- a/src/main/java/com/group11/shelftalk/service/OpenLibraryBook.java
+++ b/src/main/java/com/group11/shelftalk/service/OpenLibraryBook.java
@@ -1,0 +1,69 @@
+package com.group11.shelftalk.service;
+
+import java.util.List;
+
+public class OpenLibraryBook {
+    private String title;
+    private List<String> isbn;
+    private Integer number_of_pages_median;
+    private List<String> author_name;
+    private List<String> first_sentence;
+    private String cover_edition_key;
+    private Integer cover_i;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public List<String> getIsbn() {
+        return isbn;
+    }
+
+    public void setIsbn(List<String> isbn) {
+        this.isbn = isbn;
+    }
+
+    public Integer getNumber_of_pages_median() {
+        return number_of_pages_median;
+    }
+
+    public void setNumber_of_pages_median(Integer number_of_pages_median) {
+        this.number_of_pages_median = number_of_pages_median;
+    }
+
+    public List<String> getAuthor_name() {
+        return author_name;
+    }
+
+    public void setAuthor_name(List<String> author_name) {
+        this.author_name = author_name;
+    }
+
+    public List<String> getFirst_sentence() {
+        return first_sentence;
+    }
+
+    public void setFirst_sentence(List<String> first_sentence) {
+        this.first_sentence = first_sentence;
+    }
+
+    public String getCover_edition_key() {
+        return cover_edition_key;
+    }
+
+    public void setCover_edition_key(String cover_edition_key) {
+        this.cover_edition_key = cover_edition_key;
+    }
+
+    public Integer getCover_i() {
+        return cover_i;
+    }
+
+    public void setCover_i(Integer cover_i) {
+        this.cover_i = cover_i;
+    }
+}

--- a/src/main/java/com/group11/shelftalk/service/OpenLibraryResponse.java
+++ b/src/main/java/com/group11/shelftalk/service/OpenLibraryResponse.java
@@ -1,0 +1,15 @@
+package com.group11.shelftalk.service;
+
+import java.util.List;
+
+public class OpenLibraryResponse {
+    private List<OpenLibraryBook> docs; 
+
+    public List<OpenLibraryBook> getDocs() {
+        return docs;
+    }
+
+    public void setDocs(List<OpenLibraryBook> docs) {
+        this.docs = docs;
+    }
+}


### PR DESCRIPTION
This PR creates a service for book retrieval from OpenLibrary books API. The service retrieves books based on 15 genres and only a max of 1500 books. This service should only be run once in the lifespan of the API and the DB it is connected to. 
Completes issue #8 

Test showing it was successfully run:
![image](https://github.com/user-attachments/assets/a8950e9d-8639-48b1-96f6-5ecf456a422c)
